### PR TITLE
必要無くなったrexmlを削除

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,8 +66,6 @@ group :test do
   gem 'selenium-webdriver', require: false
 end
 
-gem 'rexml', require: false
-
 gem 'omniauth-google-oauth2'
 gem 'omniauth-rails_csrf_protection'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -390,7 +390,6 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.1)
-  rexml
   rspec-rails
   rubocop
   rubocop-capybara


### PR DESCRIPTION
最初の環境構築時には必要だったrexmlが使わなくても問題なくなったようなので削除した

参考
- https://github.com/Shopify/erb_lint/issues/371
- https://github.com/Shopify/erb_lint/pull/374
先週マージされている