### PR TITLE
meal_plansの削除ではなくmealsの削除になるように変更

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,3 +34,6 @@ RSpec/ExampleLength:
 
 RSpec/MultipleExpectations:
   Enabled: false
+
+Layout/LineLength:
+  Max: 150

--- a/app/controllers/meal_plans_controller.rb
+++ b/app/controllers/meal_plans_controller.rb
@@ -38,8 +38,8 @@ class MealPlansController < ApplicationController
   end
 
   def destroy
-    @meal_plan.destroy!
-    redirect_to meal_plans_path, notice: 'MealPlan was successfully destroyed.', status: :see_other
+    @meal_plan.meals.each(&:destroy!)
+    redirect_to meal_plans_path(meal_date: @meal_plan.meal_date), status: :see_other
   end
 
   def calendar

--- a/app/models/meal_plan.rb
+++ b/app/models/meal_plan.rb
@@ -35,9 +35,7 @@ class MealPlan < ApplicationRecord
 
   def destroy_unnecessary_meals(attributes)
     attributes[:meals_attributes].each_value do |update_meal|
-      if update_meal[:id].present? && update_meal.except(:id, :timing).values.all?(&:blank?)
-        meals.find(update_meal[:id]).destroy
-      end
+      meals.find(update_meal[:id]).destroy if update_meal[:id].present? && update_meal.except(:id, :timing).values.all?(&:blank?)
     end
   end
 

--- a/app/views/meal_plans/_meal_plan.html.erb
+++ b/app/views/meal_plans/_meal_plan.html.erb
@@ -6,7 +6,12 @@
     <% @meal_plan.meals_sort_by_timing.each do |meal| %>
       <%= render 'meals/meal', meal: %>
     <% end %>
-    <%= link_to '編集', edit_meal_plan_path(@meal_plan),
-                class: 'mt-2 rounded-lg py-3 px-5 text-stone-500 bg-stone-100 inline-block' %>
+    <% if @meal_plan.meals.blank? %>
+      <%= link_to '献立登録', new_meal_plan_path(meal_date: @meal_plan.meal_date), data: { turbo_frame: '_top' },
+                                                                               class: 'mt-2 rounded-lg py-3 px-5 text-stone-500 bg-stone-100' %>
+    <% else %>
+      <%= link_to '編集', edit_meal_plan_path(@meal_plan),
+                  class: 'mt-2 rounded-lg py-3 px-5 text-stone-500 bg-stone-100' %>
+    <% end %>
   </div>
 <% end %>


### PR DESCRIPTION
- #107 

turbo-frameの都合上、formからの更新でmeal_planのもつmealsが0になった場合はmeal_planの詳細画面からnew_meal_plan_pathへのリンクを追加して対応。
mealを全部消す仕様を上記のupdateからだけにすることも可能だが、画面がmeal_planから遷移しないためあまり使い勝手が良くない。
ルーティングにDELETEを追加しdestroyアクションでmeal_planのもつmealsを全部削除して献立表一覧にリダイレクトするようにした。