### PR TITLE
MealPlanモデルのupdate_meal_planメソッドを分割した

### DIFF
--- a/app/controllers/meals_controller.rb
+++ b/app/controllers/meals_controller.rb
@@ -5,4 +5,24 @@ class MealsController < ApplicationController
     @meal_plan = current_user.family.meal_plans.find(params[:meal_plan_id])
     @meal = Meal.build(name: @meal_plan.meeting_room.remarks.find(params[:remark]).content)
   end
+
+  def create
+    meal = Meal.build(meal_params)
+    meal_plan = current_user.family.meal_plans.find(meal_plan_id)
+    if meal.create_or_update_meal_name(meal_plan)
+      redirect_to meal_plan, notice: '登録しました'
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def meal_params
+    params.require(:meal).permit(:id, :timing, :name, :memo)
+  end
+
+  def meal_plan_id
+    params.require(:meal_plan_id)
+  end
 end

--- a/app/models/meal.rb
+++ b/app/models/meal.rb
@@ -6,4 +6,16 @@ class Meal < ApplicationRecord
   enum :timing, { breakfast: 0, lunch: 1, dinner: 2 }, validate: true
 
   validates :timing, presence: true, uniqueness: { scope: :meal_plan_id }
+
+  def create_or_update_meal_name(meal_plan)
+    same_timing_meal = meal_plan.meals.find_by(timing: self[:timing])
+    if same_timing_meal.nil?
+      self.meal_plan = meal_plan
+      save
+    else
+      same_timing_meal.name = self[:name]
+      same_timing_meal.memo = ''
+      same_timing_meal.save
+    end
+  end
 end

--- a/app/models/meal_plan.rb
+++ b/app/models/meal_plan.rb
@@ -11,14 +11,10 @@ class MealPlan < ApplicationRecord
   accepts_nested_attributes_for :meals, allow_destroy: true, reject_if: :reject_timing
 
   def update_meal_plan(attributes)
-    if attributes[:meals_attributes].keys.size == 1
-      create_or_update_meals_by_proposal(attributes)
-    else
-      assign_attributes(attributes)
-      return unless save
+    assign_attributes(attributes)
+    return unless save
 
-      destroy_unnecessary_meals(attributes)
-    end
+    destroy_unnecessary_meals(attributes)
   end
 
   def meals_build
@@ -39,17 +35,6 @@ class MealPlan < ApplicationRecord
     return if meal_names.any?(&:present?)
 
     errors.add(:base, '料理名を最低1つ入力してください')
-  end
-
-  def create_or_update_meals_by_proposal(attributes)
-    new_meal_params = attributes[:meals_attributes]['0']
-    same_timing_meal = meals.find_by(timing: new_meal_params[:timing])
-    if same_timing_meal.nil?
-      meals.create(new_meal_params)
-    else
-      same_timing_meal.name = new_meal_params[:name]
-      same_timing_meal.save
-    end
   end
 
   def destroy_unnecessary_meals(attributes)

--- a/app/views/meals/_timing_form.html.erb
+++ b/app/views/meals/_timing_form.html.erb
@@ -1,26 +1,23 @@
-<%= form_with(model: meal_plan, url: meal_plan_path(meal_plan), method: 'patch') do |form| %>
-  <% if meal_plan.errors.any? %>
+<%= form_with(model: [meal_plan, meal]) do |form| %>
+  <% if meal.errors.any? %>
     <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">
       <ul>
-        <% meal_plan.errors.each do |error| %>
+        <% meal.errors.each do |error| %>
           <li><%= error.full_message %></li>
         <% end %>
       </ul>
     </div>
   <% end %>
   <div class="my-6">
-    <%= form.hidden_field :meal_date %>
-    <%= form.fields_for :meals, meal do |meal_form| %>
-        <%= meal_form.hidden_field :id %>
-        <div class="checkbox-3 flex justify-around">
-          <% Meal.timings.keys.each do |timing| %>
-            <%= meal_form.radio_button :timing, timing, checked: (timing == 'lunch'), class: 'checkbox-3' %>
-            <%= meal_form.label "timing_#{timing}", Meal.human_attribute_name("timing.#{timing}") %>
-          <% end %>
-        </div>
-        <%= meal_form.hidden_field :name, value: meal_form.object.name %>
-        <%= meal_form.hidden_field :memo, value: '' %>
-    <% end %>
+    <%= form.hidden_field :id %>
+    <div id="timing_checkbox" class="checkbox-3 flex justify-around">
+      <% Meal.timings.keys.each do |timing| %>
+        <%= form.radio_button :timing, timing, checked: (timing == 'lunch'), class: 'checkbox-3' %>
+        <%= form.label "timing_#{timing}", Meal.human_attribute_name("timing.#{timing}") %>
+      <% end %>
+    </div>
+    <%= form.hidden_field :name, value: form.object.name %>
+    <%= form.hidden_field :memo, value: '' %>
   </div>
   <div class="m-2 text-center">
     <%= form.submit '登録', class: 'rounded-full py-3 px-7 bg-red-400 text-white' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
   get 'family', to: 'families#show', as: 'family'
   get 'meal_plans/calendar', to: 'meal_plans#calendar'
   resources :meal_plans do
-    resources :meals, only: %i[new]
+    resources :meals, only: %i[new create]
   end
   resources :meeting_rooms, only: %i[show create] do
     resources :remarks, only: %i[new create edit update destroy]

--- a/spec/factories/meeting_room.rb
+++ b/spec/factories/meeting_room.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :meeting_room do
+    family
+    meal_plan
+  end
+end

--- a/spec/factories/remark.rb
+++ b/spec/factories/remark.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :remark do
+    user
+    meeting_room
+    content { 'RemarkContent' }
+  end
+end

--- a/spec/models/meal_plan_spec.rb
+++ b/spec/models/meal_plan_spec.rb
@@ -7,34 +7,11 @@ RSpec.describe MealPlan, type: :model do
   let(:meal_plan) { create(:meal_plan, :with_breakfast_and_dinner, family: user.family) }
 
   describe '#update_meal_plan' do
-    let(:breakfast_params) { { id: meal_plan.meals.find_by(timing: 'breakfast').id, name: '朝ごはん', memo: '', timing: 'breakfast' } }
-    let(:lunch_params) { { id: nil, name: '昼ごはん', memo: '', timing: 'lunch' } }
-    let(:dinner_params) { { id: meal_plan.meals.find_by(timing: 'dinner').id, name: '', memo: '', timing: 'dinner' } }
-
-    it 'meal_planのmealが1つ渡され、同じタイミングのmealがないとき、mealが新規保存される' do
-      lunch_meal_params = ActionController::Parameters.new(meals_attributes: ActionController::Parameters.new('0': lunch_params)).permit(
-        meals_attributes: %i[id name memo timing]
-      )
-      meal_plan.update_meal_plan(lunch_meal_params)
-      meal_plan.meals.reload
-      expect(meal_plan.meals.map(&:name).sort).to eq %w[BreakfastName DinnerName 昼ごはん]
-      expect(meal_plan.meals.map(&:timing).sort).to eq %w[breakfast dinner lunch]
-    end
-
-    it 'meal_planのmealが1つ渡され、同じタイミングのmealがすでにあるとき、mealが上書き保存される' do
-      breakfast_meal_params = ActionController::Parameters.new(meals_attributes: ActionController::Parameters.new('0': breakfast_params)).permit(
-        meals_attributes: %i[id name memo timing]
-      )
-      meal_plan.update_meal_plan(breakfast_meal_params)
-      meal_plan.meals.reload
-      expect(meal_plan.meals.map(&:name).sort).to eq %w[DinnerName 朝ごはん]
-      expect(meal_plan.meals.map(&:timing).sort).to eq %w[breakfast dinner]
-    end
-
-    it 'meal_planのmealが3つ渡されたときにmealsは更新され不要なmealは削除される' do
-      three_meals_params = ActionController::Parameters.new(meals_attributes: ActionController::Parameters.new('0': breakfast_params, '1': lunch_params, '2': dinner_params)).permit(
-        meals_attributes: %i[id name memo timing]
-      )
+    it 'meal_planのmealsを渡すとmealを更新して不要なmealは削除する' do
+      breakfast_params = { id: meal_plan.meals.find_by(timing: 'breakfast').id, name: '朝ごはん', memo: '', timing: 'breakfast' }
+      lunch_params = { id: nil, name: '昼ごはん', memo: '', timing: 'lunch' }
+      dinner_params = { id: meal_plan.meals.find_by(timing: 'dinner').id, name: '', memo: '', timing: 'dinner' }
+      three_meals_params = { meals_attributes: { '0': breakfast_params, '1': lunch_params, '2': dinner_params } }
       meal_plan.update_meal_plan(three_meals_params)
       meal_plan.meals.reload
       expect(meal_plan.meals.map(&:name).sort).to eq %w[昼ごはん 朝ごはん]

--- a/spec/models/meal_spec.rb
+++ b/spec/models/meal_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Meal, type: :model do
+  let(:user) { create(:user) }
+  let(:meal_plan) { create(:meal_plan, :with_breakfast_and_dinner, family: user.family) }
+
+  describe '#create_or_udpate_meal_name' do
+    it 'meal_planに同じタイミングのmealがないとき、mealが新規保存される' do
+      meal = build(:meal, name: '昼ごはん', timing: 'lunch')
+      meal.create_or_update_meal_name(meal_plan)
+      meal_plan.meals.reload
+      expect(meal_plan.meals.map(&:name).sort).to eq %w[BreakfastName DinnerName 昼ごはん]
+      expect(meal_plan.meals.map(&:timing).sort).to eq %w[breakfast dinner lunch]
+    end
+
+    it 'meal_planに同じタイミングのmealがすでにあるとき、mealが上書き保存される' do
+      meal = build(:meal, name: '朝ごはん', timing: 'breakfast')
+      meal.create_or_update_meal_name(meal_plan)
+      meal_plan.meals.reload
+      expect(meal_plan.meals.map(&:name).sort).to eq %w[DinnerName 朝ごはん]
+      expect(meal_plan.meals.map(&:timing).sort).to eq %w[breakfast dinner]
+    end
+  end
+end

--- a/spec/system/meals_spec.rb
+++ b/spec/system/meals_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Meals', type: :system do
+  let(:user) { create(:user) }
+  let(:meal_plan) { create(:meal_plan, :with_3_meals, family: user.family) }
+  let(:meeting_room) { create(:meeting_room, family: user.family, meal_plan:) }
+  let(:proposal) { create(:remark, user:, meeting_room:, remark_type: 0, content: 'カレー') }
+
+  before do
+    log_in_as user
+  end
+
+  it '提案から献立を登録する' do
+    visit new_meal_plan_meal_path(meal_plan, remark: proposal)
+
+    within '#timing_checkbox' do
+      choose '夜ごはん'
+    end
+    click_on '登録'
+
+    expect(page).to have_content '登録しました'
+    expect(page).to have_content 'BreakfastName'
+    expect(page).to have_content 'LunchName'
+    expect(page).to have_content 'カレー'
+  end
+end


### PR DESCRIPTION
 理由：MealPlanモデルのupdate_meal_planメソッドが複雑なため

 やったこと：
- ルーティングにcreateを追加
- Mealコントローラにcreateアクションの追加
- Mealモデルにcreate_or_update_meal_nameメソッドを追加
- MealPlanモデルのupdate_meal_planメソッドから条件分岐部を削除し修正
- 提案から献立を登録するformの修正
- モデルテストの追加修正
- 提案から献立を登録するシステムテストの追加