### PR TITLE
 bulletの設定を追加

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,9 @@ Rails/BulkChangeTable:
 Metrics/AbcSize:
   Max: 25
 
+Metrics/BlockLength:
+  Max: 50
+
 Rails/I18nLocaleTexts:
   Enabled: false
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -3,6 +3,17 @@
 require 'active_support/core_ext/integer/time'
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.alert         = true
+    Bullet.bullet_logger = true
+    Bullet.console       = true
+    Bullet.rails_logger  = true
+    Bullet.add_footer    = true
+
+    Bullet.add_safelist type: :unused_eager_loading, class_name: 'MealPlan', association: :meal
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time


### PR DESCRIPTION
mealsがない状態のときに`includes([:meals])`を削除するようポップアップで出ていたが、mealsが追加されたあとのN+1を解消するために必要なので、それをスキップするよう設定を追加した