### PR TITLE
献立表ページ（週）のレイアウトを修正

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -133,6 +133,8 @@ textarea::placeholder {
   width: 1rem;
   height: 2rem;
   position: relative;
+  padding: 1.5rem;
+  margin: 0 0.5rem 0 0;
 }
 
 .arrow_left::before {
@@ -158,6 +160,8 @@ textarea::placeholder {
   width: 1rem;
   height: 2rem;
   position: relative;
+  padding: 1.5rem;
+  margin: 0 0 0 0.5rem;
 }
 
 .arrow_right::before {

--- a/app/controllers/meal_plans_controller.rb
+++ b/app/controllers/meal_plans_controller.rb
@@ -4,7 +4,7 @@ class MealPlansController < ApplicationController
   before_action :set_meal_plan, only: %i[show edit update destroy]
 
   def index
-    @meal_plans = current_user.family.meal_plans.includes([:meals])
+    @meal_plans = current_user.family.meal_plans.includes([:meals]).includes([:meeting_room])
   end
 
   def show; end

--- a/app/helpers/meal_plans_helper.rb
+++ b/app/helpers/meal_plans_helper.rb
@@ -1,6 +1,26 @@
 # frozen_string_literal: true
 
 module MealPlansHelper
+  def meal_plan_link(meal_plan, date)
+    if meal_plan&.meals.blank?
+      new_meal_plan_path(meal_date: date)
+    else
+      meal_plan
+    end
+  end
+
+  def meals_length(meal_plan)
+    meal_plan&.meals&.length.to_i
+  end
+
+  def proposals_length(meal_plan)
+    meal_plan&.meeting_room&.remarks&.proposals&.length.to_i
+  end
+
+  def comments_length(meal_plan)
+    meal_plan&.meeting_room&.remarks&.comments&.length.to_i
+  end
+
   def button_display
     if action_name == 'new'
       I18n.t 'helpers.submit.create'

--- a/app/views/layouts/_title_meal_date.html.erb
+++ b/app/views/layouts/_title_meal_date.html.erb
@@ -1,4 +1,4 @@
-<div class="px-4 py-1.5 flex justify-center items-center bg-orange-200">
+<div class="h-10 flex justify-center items-center bg-orange-200">
   <%= link_to '', meal_plans_path(start_date: meal_date),
               class: 'inline-block text-left font-bold arrow_left' %>
   <h1 class="mx-auto text-center font-bold text-xl"><%= l meal_date, format: format_date_length_whether_this_year(meal_date) %></h1>

--- a/app/views/meal_plans/_counter.html.erb
+++ b/app/views/meal_plans/_counter.html.erb
@@ -1,0 +1,24 @@
+<%= button_to meeting_rooms_path(meal_plan:, meal_date: date), method: :post do %>
+  <% if (meals_length(meal_plan) + proposals_length(meal_plan) + comments_length(meal_plan)).zero? %>
+    <div class="text-left rounded-lg border-4 border-double border-red-900/20 hover:bg-red-100">
+      <div class="text-xs text-center px-3 py-4">
+        会議室は<br>こちら
+      </div>
+    </div>
+  <% else %>
+    <div class="text-left rounded-lg border-2 border-red-900/20 divide-y-2 divide-red-900/10 hover:bg-red-100/50">
+      <div class="pl-3 pr-3.5 py-0.5 flex items-center justify-between">
+        <%= image_tag('pages/meal.svg', class: 'w-4 ml-0.5 mr-2', alt: '献立のマーク') %>
+        <%= meals_length(meal_plan) %>/3
+      </div>
+      <div class="pl-3 pr-3.5 py-0.5 flex items-center justify-between">
+        <%= image_tag('pages/light.svg', class: 'w-4 ml-0.5 mr-2', alt: '提案のマーク') %>
+        <%= proposals_length(meal_plan) %>
+      </div>
+      <div class="pl-3 pr-3.5 py-0.5 flex items-center justify-between">
+        <%= image_tag('pages/chat_single.svg', class: 'w-5 mr-1', alt: 'コメントのマーク') %>
+        <%= comments_length(meal_plan) %>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/meal_plans/_counter.html.erb
+++ b/app/views/meal_plans/_counter.html.erb
@@ -1,12 +1,10 @@
 <%= button_to meeting_rooms_path(meal_plan:, meal_date: date), method: :post do %>
   <% if (meals_length(meal_plan) + proposals_length(meal_plan) + comments_length(meal_plan)).zero? %>
-    <div class="text-left rounded-lg border-4 border-double border-red-900/20 hover:bg-red-100">
-      <div class="text-xs text-center px-3 py-4">
-        会議室は<br>こちら
-      </div>
+    <div class="text-xs text-center px-3 py-4 rounded-lg border-4 border-double border-orange-900/20 hover:bg-orange-700/10">
+      会議室は<br>こちら
     </div>
   <% else %>
-    <div class="text-left rounded-lg border-2 border-red-900/20 divide-y-2 divide-red-900/10 hover:bg-red-100/50">
+    <div class="rounded-lg border-2 border-orange-900/20 divide-y-2 divide-orange-900/10 hover:bg-orange-600/10">
       <div class="pl-3 pr-3.5 py-0.5 flex items-center justify-between">
         <%= image_tag('pages/meal.svg', class: 'w-4 ml-0.5 mr-2', alt: '献立のマーク') %>
         <%= meals_length(meal_plan) %>/3

--- a/app/views/meal_plans/index.html.erb
+++ b/app/views/meal_plans/index.html.erb
@@ -1,25 +1,25 @@
 <% set_meta_tags title: '献立表' %>
 <% set_meta_tags description: '献立表のページです。' %>
 <div class="w-full">
-  <div>
-    <%= week_calendar events: @meal_plans do |date, meal_plan| %>
-      <div class="flex items-center">
-        <div class="block w-2/3 hover:bg-orange-100 rounded-lg m-1 px-2 md:px-4 py-2">
-          <%= link_to meal_plan_link(meal_plan, date) do %>
-            <% Meal.timings.each_key do |timing| %>
-              <div class="flex items-center my-1">
-                <%= image_tag("meals/#{timing}.svg", class: 'w-5 mr-4', alt: alt_meal_timing(timing)) %>
-                <span class="truncate">
-                  <%= meal_plan&.meals&.find_by(timing:)&.name || content_tag(:span, '未確定', class: 'text-orange-950/20') %>
-                </span>
-              </div>
-            <% end %>
+  <%= week_calendar events: @meal_plans do |date, meal_plan| %>
+    <div class="flex items-center justify-around">
+      <div class="inline-block w-2/3 md:w-3/4 hover:bg-orange-100 rounded-lg my-1 pl-1.5 md:px-4 py-2">
+        <%= link_to meal_plan_link(meal_plan, date) do %>
+          <% Meal.timings.each_key do |timing| %>
+            <div class="flex items-center my-1">
+              <%= image_tag("meals/#{timing}.svg", class: 'w-5 mr-2', alt: alt_meal_timing(timing)) %>
+              <span class="truncate block max-w-[170px] md:max-w-[350px]">
+                <%= meal_plan&.meals&.find_by(timing:)&.name || content_tag(:span, '未確定', class: 'text-orange-950/20') %>
+              </span>
+            </div>
           <% end %>
-        </div>
+        <% end %>
+      </div>
+      <div class="w-1/3 md:w-1/4 text-center mr-2 md:mr-6">
         <%= render 'counter', meal_plan: meal_plan, date: %>
       </div>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
 </div>
 <% if session[:welcome_modal] %>
   <%= render 'welcome_modal' %>

--- a/app/views/meal_plans/index.html.erb
+++ b/app/views/meal_plans/index.html.erb
@@ -3,29 +3,21 @@
 <div class="w-full">
   <div>
     <%= week_calendar events: @meal_plans do |date, meal_plan| %>
-      <% if meal_plan&.meals.blank? %>
-        <div class="flex items-center h-14">
-          <%= button_to meeting_rooms_path(meal_plan:, meal_date: date), method: :post,
-                                                                         class: 'absolute left-1/2 transform -translate-x-1/2 -translate-y-1/2 ml-2 meeting_room_button font-medium' do %>
-            <%= image_tag('pages/chat_double.svg', class: 'meal-icon', alt: 'チャットのマーク') %>
-            <span class="ml-1">会議へ</span>
+      <div class="flex items-center">
+        <div class="block w-2/3 hover:bg-orange-100 rounded-lg m-1 px-2 md:px-4 py-2">
+          <%= link_to meal_plan_link(meal_plan, date) do %>
+            <% Meal.timings.each_key do |timing| %>
+              <div class="flex items-center my-1">
+                <%= image_tag("meals/#{timing}.svg", class: 'w-5 mr-4', alt: alt_meal_timing(timing)) %>
+                <span class="truncate">
+                  <%= meal_plan&.meals&.find_by(timing:)&.name || content_tag(:span, '未確定', class: 'text-orange-950/20') %>
+                </span>
+              </div>
+            <% end %>
           <% end %>
-          <%= link_to '', new_meal_plan_path(meal_date: date), id: 'plus_icon', class: 'plus_icon right-15' %>
         </div>
-      <% else %>
-        <%= link_to meal_plan do %>
-          <div class="text-left flex items-center h-full min-h-14 w-full hover:bg-orange-100 rounded-lg">
-            <ul class="w-4/5 mx-auto pl-4 inline-block">
-              <% meal_plan.meals.sort_by_timing.each do |meal| %>
-                <li class="flex justify-start items-center my-1">
-                  <%= image_tag("meals/#{meal.timing}.svg", class: 'meal-icon text-center mr-2', alt: alt_meal_timing(meal.timing)) %>
-                  <%= meal.name %>
-                </li>
-              <% end %>
-            </ul>
-          </div>
-        <% end %>
-      <% end %>
+        <%= render 'counter', meal_plan: meal_plan, date: %>
+      </div>
     <% end %>
   </div>
 </div>

--- a/app/views/simple_calendar/_week_calendar.html.erb
+++ b/app/views/simple_calendar/_week_calendar.html.erb
@@ -1,6 +1,6 @@
 <div>
-  <div class="relative ml-6 my-2 min-h-10 flex items-center">
-    <div class="absolute left-0 w-1/4 flex">
+  <div class="h-10 flex items-center justify-around bg-orange-200">
+    <div class="">
       <span class="font-semibold">
         <time datetime="<%= start_date.strftime('%Y-%m') %>">
           <%= "#{start_date.year}年" %>
@@ -8,14 +8,14 @@
       </span>
     </div>
 
-    <nav class="absolute left-1/2 transform -translate-x-1/2 flex items-center space-x-3">
+    <nav class="flex items-center">
       <%= link_to '', calendar.url_for_previous_view,
                   class: 'arrow_left' %>
-      <%= link_to t('simple_calendar.week.today'), calendar.url_for_today_view,
-                  class: 'hover:font-bold pr-1' %>
       <%= link_to '', calendar.url_for_next_view,
                   class: 'arrow_right' %>
     </nav>
+    <%= link_to t('simple_calendar.week.today'), calendar.url_for_today_view,
+                class: 'rounded-full px-3 py-1 border border-orange-950 hover:bg-orange-300' %>
   </div>
 
   <table class="w-full table-fixed border-collapse">

--- a/app/views/simple_calendar/_week_calendar.html.erb
+++ b/app/views/simple_calendar/_week_calendar.html.erb
@@ -22,14 +22,14 @@
     <tbody>
     <% date_range.each do |day| %>
       <tr id="<%= day.strftime('row%Y%m%d') %>" class="relative border-t border-dashed border-orange-900/10">
-        <th class="w-1/4 items-center text-left p-3 text-orange-950/70">
+        <th class="w-1/6 items-center text-left pl-2 text-orange-950/70">
           <p class="text-center"><%= l day, format: :short %></p>
           <p class="text-center">
             <%= t('date.abbr_day_names')[day.wday] %>
           </p>
         </th>
 
-        <td id="<%= cell_day(day) %>" class="w-5/6 p-3">
+        <td id="<%= cell_day(day) %>" class="w-5/6">
           <%= content_tag :div, class: calendar.td_classes_for(day) do %>
             <% instance_exec(day, calendar.sorted_events_for(day).first, &passed_block) %>
           <% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -12,6 +12,7 @@ Rails.application.configure do
     Bullet.add_footer    = true
 
     Bullet.add_safelist type: :unused_eager_loading, class_name: 'MealPlan', association: :meals
+    Bullet.add_safelist type: :unused_eager_loading, class_name: 'MealPlan', association: :meeting_room
   end
 
   # Settings specified here will take precedence over those in config/application.rb.

--- a/spec/helpers/meal_plans_helper_spec.rb
+++ b/spec/helpers/meal_plans_helper_spec.rb
@@ -3,6 +3,76 @@
 require 'rails_helper'
 
 RSpec.describe MealPlansHelper, type: :helper do
+  let(:user) { create(:user) }
+  let(:meal_plan) { create(:meal_plan, :with_breakfast_and_dinner, family: user.family) }
+  let(:meeting_room) { create(:meeting_room, family: user.family, meal_plan:) }
+
+  describe '#meal_plan_link' do
+    let(:date) { Time.zone.today }
+
+    it 'meal_planが存在しないときnew_meal_plan_pathを返す' do
+      expect(meal_plan_link(nil, date)).to eq(new_meal_plan_path(meal_date: date))
+    end
+
+    it 'meal_planは存在するがmealが存在しないときnew_meal_plan_pathを返す' do
+      meal_plan = instance_double(MealPlan, meals: [])
+      expect(meal_plan_link(meal_plan, date)).to eq(new_meal_plan_path(meal_date: date))
+    end
+
+    it 'meal_planとmealが登録されているときmeal_planを返す' do
+      meal_plan
+      expect(meal_plan_link(meal_plan, date)).to eq(meal_plan)
+    end
+  end
+
+  describe '#meals_length' do
+    it 'meal_planが存在しないとき0を返す' do
+      expect(meals_length(nil)).to eq(0)
+    end
+
+    it 'meal_planは存在するがmealが存在しないとき0を返す' do
+      meal_plan = instance_double(MealPlan, meals: nil)
+      expect(meals_length(meal_plan)).to eq(0)
+    end
+
+    it 'meal_planとmealが２食分登録されているとき２を返す' do
+      meal_plan
+      expect(meals_length(meal_plan)).to eq(2)
+    end
+  end
+
+  describe '#proposals_length' do
+    it 'meeting_roomが存在しないとき0を返す' do
+      meal_plan = instance_double(MealPlan, meeting_room: nil)
+      expect(proposals_length(meal_plan)).to eq(0)
+    end
+
+    it 'meeting_roomは存在するがproposalsが存在しないとき0を返す' do
+      expect(proposals_length(meal_plan)).to eq(0)
+    end
+
+    it 'proposalが1つ登録されているとき1を返す' do
+      create(:remark, remark_type: 0, content: 'カレー', meeting_room:, user:)
+      expect(proposals_length(meal_plan)).to eq(1)
+    end
+  end
+
+  describe '#comments_length' do
+    it 'meeting_roomが存在しないとき0を返す' do
+      meal_plan = instance_double(MealPlan, meeting_room: nil)
+      expect(comments_length(meal_plan)).to eq(0)
+    end
+
+    it 'meeting_roomは存在するがcommentsが存在しないとき0を返す' do
+      expect(comments_length(meal_plan)).to eq(0)
+    end
+
+    it 'commentが1つ登録されているとき1を返す' do
+      create(:remark, remark_type: 1, content: '簡単に作れるものにしよう', meeting_room:, user:)
+      expect(comments_length(meal_plan)).to eq(1)
+    end
+  end
+
   describe '#button_display' do
     it 'newアクションのとき「登録」を返す' do
       allow(helper).to receive(:action_name).and_return('new')

--- a/spec/system/meal_plans_spec.rb
+++ b/spec/system/meal_plans_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'MealPlans', type: :system do
   it '献立を登録する' do
     visit meal_plans_path(start_date: Time.zone.today)
     within "##{cell_day(Time.zone.today)}" do
-      find_by_id('plus_icon').click
+      click_on '未確定'
     end
 
     expect(page).to have_content I18n.l(Time.zone.today, format: :medium)
@@ -45,7 +45,7 @@ RSpec.describe 'MealPlans', type: :system do
   it '献立をなにも入力せず登録しようとしてバリデーションエラーが出る' do
     visit meal_plans_path(start_date: Time.zone.today)
     within "##{cell_day(Time.zone.today)}" do
-      find_by_id('plus_icon').click
+      click_on '未確定'
     end
 
     expect(page).to have_content I18n.l(Time.zone.today, format: :medium)
@@ -58,7 +58,7 @@ RSpec.describe 'MealPlans', type: :system do
   it '料理名を20文字以上、メモを200文字以上入力して登録しようとしてバリデーションエラーが出る' do
     visit meal_plans_path(start_date: Time.zone.today)
     within "##{cell_day(Time.zone.today)}" do
-      find_by_id('plus_icon').click
+      click_on '未確定'
     end
 
     expect(page).to have_content I18n.l(Time.zone.today, format: :medium)

--- a/spec/system/meeting_rooms_spec.rb
+++ b/spec/system/meeting_rooms_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'MeetingRooms', type: :system do
   it '献立表一覧から会議室へ遷移する' do
     visit meal_plans_path(start_date: Time.zone.today)
     within "##{cell_day(Time.zone.today)}" do
-      click_on '会議へ'
+      click_on('会議室はこちら')
     end
 
     expect(page).to have_content I18n.l(Time.zone.today, format: :medium)


### PR DESCRIPTION
- 献立が決まっていないところに「未確定」と表示
  - 3食全部献立が決まっていないときは献立新規作成へリンク
  - 1食でも献立が決まっていたら献立詳細へリンク
- 右側に確定した献立・提案・コメントのカウンターを追加
  - 会議室へリンク
- 見出しの調整